### PR TITLE
POST YEAR ONE SUBMISSION - moved API call to backend, changed routes

### DIFF
--- a/app/controllers/api/films_controller.rb
+++ b/app/controllers/api/films_controller.rb
@@ -1,4 +1,4 @@
-class Api::FilmsController < ApplicationController
+class Api::FilmsController < ApplicationController 
 
     def search
       title = params[:title]
@@ -51,9 +51,16 @@ class Api::FilmsController < ApplicationController
     end
 
     def show
-      @film = Film.find(params[:id])
-      render "show.json.jb"
+      added_info = HTTParty.get("https://movie-database-imdb-alternative.p.rapidapi.com?i=#{params[:imdb]}&r=json", {
+        headers: {
+        'x-rapidapi-key' => 'e979f7406cmsh363d1f98423c118p197d7bjsnce1e962638fd',
+        'x-rapidapi-host' => 'movie-database-imdb-alternative.p.rapidapi.com'
+        }
+      })
+      puts added_info
+      render json: added_info
     end
+   
 
     def update
       @film = Film.find_by(imdb_number: params[:imdb_number])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,6 @@ Rails.application.routes.draw do
 
     patch "/films/:imdb" => "films#update"
 
-    get "/films/:id" => "films#show"
+    get "/films/:imdb" => "films#show"
   end
 end


### PR DESCRIPTION
One of my API calls, the one attached to the "more info" button on the Movie component, was stored on the frontend, so I moved it to the back so I wouldn't expose my API key on the frontend. 